### PR TITLE
feat: Add `soon` Labes Support

### DIFF
--- a/lib/newsman/github.rb
+++ b/lib/newsman/github.rb
@@ -45,7 +45,7 @@ class Github
     puts "Searching issues using the following query: '#{query}'"
     @client.search_issues(query).items.map do |issue|
       parse_issue(issue)
-    end
+    end.select(&:important?)
   end
 
   def parse_pr(pull_request)
@@ -58,9 +58,9 @@ class Github
   def parse_issue(issue)
     title, repository, number = issue_details(issue)
     if issue.user.login == '0pdd'
-      PddIssue.new(title, issue.body.to_s, repository, number, url: issue.html_url)
+      PddIssue.new(title, issue.body.to_s, repository, number, url: issue.html_url, labels: issue.labels.map(&:name))
     else
-      Issue.new(title, issue.body.to_s, repository, number, url: issue.html_url)
+      Issue.new(title, issue.body.to_s, repository, number, url: issue.html_url, labels: issue.labels.map(&:name))
     end
   end
 

--- a/lib/newsman/issues.rb
+++ b/lib/newsman/issues.rb
@@ -26,9 +26,8 @@ require 'json'
 # This class represents a GitHub Issue abstraction created by a user.
 class Issue
   attr_accessor :title, :body, :repo, :number
-  attr_reader :url
 
-  def initialize(title, body, repo, number, **additional) 
+  def initialize(title, body, repo, number, **additional)
     defaults = { url: 'undefined', labels: [] }
     @title = title
     @body = body
@@ -56,7 +55,7 @@ class Issue
       title: @title,
       description: @body,
       repository: @repo,
-      url: url 
+      url:
     }.to_json
   end
 
@@ -77,7 +76,7 @@ end
 class PddIssue
   attr_accessor :repo
 
-  def initialize(title, body, repo, number, **additional) 
+  def initialize(title, body, repo, number, **additional)
     defaults = { url: 'undefined', labels: [] }
     @title = title
     @body = body
@@ -118,7 +117,7 @@ class PddIssue
       title: @title,
       description: @body,
       repository: @repo,
-      url: url
+      url:
     }.to_json
   end
 

--- a/lib/newsman/issues.rb
+++ b/lib/newsman/issues.rb
@@ -50,26 +50,27 @@ class Issue
     "title: #{@title}, repo: #{@repo}, number: \##{@number}, url: #{url}, labels: #{labels}"
   end
 
-  def to_json(*_args)
-    {
-      number: @number,
-      title: @title,
-      description: @body,
-      repository: @repo,
-      url: url
-    }.to_json
-  end
-
-  def important?
-    labels.include? 'soon'
-  end
-
   def url
     @additional[:url]
   end
 
   def labels
     @additional[:labels]
+  end
+
+  def to_json(*_args)
+    url = url()
+    {
+      number: @number,
+      title: @title,
+      description: @body,
+      repository: @repo,
+      url:
+    }.to_json
+  end
+
+  def important?
+    labels.include? 'soon'
   end
 end
 
@@ -114,6 +115,7 @@ class PddIssue
   end
 
   def to_json(*_args)
+    url = url()
     {
       number: @number,
       title: @title,

--- a/lib/newsman/issues.rb
+++ b/lib/newsman/issues.rb
@@ -59,13 +59,12 @@ class Issue
   end
 
   def to_json(*_args)
-    url = url()
     {
       number: @number,
       title: @title,
       description: @body,
       repository: @repo,
-      url:
+      url: url.to_s
     }.to_json
   end
 
@@ -115,13 +114,12 @@ class PddIssue
   end
 
   def to_json(*_args)
-    url = url()
     {
       number: @number,
       title: @title,
       description: @body,
       repository: @repo,
-      url:
+      url: url.to_s
     }.to_json
   end
 

--- a/lib/newsman/issues.rb
+++ b/lib/newsman/issues.rb
@@ -41,12 +41,13 @@ class Issue
       title: ```#{@title}```,
       description: ```#{@body}```,
       repo: ```#{@repo}```,
-      issue number: \##{@number}
+      issue number: \##{@number},
+      additional: #{@additional}
     MARKDOWN
   end
 
   def detailed_title
-    "title: #{@title}, repo: #{@repo}, number: \##{@number}, url: #{url}"
+    "title: #{@title}, repo: #{@repo}, number: \##{@number}, url: #{url}, labels: #{labels}"
   end
 
   def to_json(*_args)
@@ -55,7 +56,7 @@ class Issue
       title: @title,
       description: @body,
       repository: @repo,
-      url:
+      url: url
     }.to_json
   end
 
@@ -103,12 +104,13 @@ class PddIssue
       title: ```#{@title}```,
       description: ```#{extract_real_body}```,
       repo: ```#{@repo}```,
-      issue number: \##{@number}
+      issue number: \##{@number},
+      additional: #{@additional}
     MARKDOWN
   end
 
   def detailed_title
-    "title: #{@title}, repo: #{@repo}, issue number: \##{@number}, url: #{url}"
+    "title: #{@title}, repo: #{@repo}, issue number: \##{@number}, url: #{url}, labels: #{labels}"
   end
 
   def to_json(*_args)

--- a/lib/newsman/issues.rb
+++ b/lib/newsman/issues.rb
@@ -28,12 +28,13 @@ class Issue
   attr_accessor :title, :body, :repo, :number
   attr_reader :url
 
-  def initialize(title, body, repo, number, url: 'undefined')
+  def initialize(title, body, repo, number, **additional) 
+    defaults = { url: 'undefined', labels: [] }
     @title = title
     @body = body
     @repo = repo
     @number = number
-    @url = url
+    @additional = defaults.merge(additional)
   end
 
   def to_s
@@ -46,7 +47,7 @@ class Issue
   end
 
   def detailed_title
-    "title: #{@title}, repo: #{@repo}, number: \##{@number}, url: #{@url}"
+    "title: #{@title}, repo: #{@repo}, number: \##{@number}, url: #{url}"
   end
 
   def to_json(*_args)
@@ -55,8 +56,20 @@ class Issue
       title: @title,
       description: @body,
       repository: @repo,
-      url: @url
+      url: url 
     }.to_json
+  end
+
+  def important?
+    labels.include? 'soon'
+  end
+
+  def url
+    @additional[:url]
+  end
+
+  def labels
+    @additional[:labels]
   end
 end
 
@@ -64,12 +77,13 @@ end
 class PddIssue
   attr_accessor :repo
 
-  def initialize(title, body, repo, number, url: 'undefined')
+  def initialize(title, body, repo, number, **additional) 
+    defaults = { url: 'undefined', labels: [] }
     @title = title
     @body = body
     @repo = repo
     @number = number
-    @url = url
+    @additional = defaults.merge(additional)
   end
 
   def extract_real_body
@@ -95,7 +109,7 @@ class PddIssue
   end
 
   def detailed_title
-    "title: #{@title}, repo: #{@repo}, issue number: \##{@number}, url: #{@url}"
+    "title: #{@title}, repo: #{@repo}, issue number: \##{@number}, url: #{url}"
   end
 
   def to_json(*_args)
@@ -104,7 +118,19 @@ class PddIssue
       title: @title,
       description: @body,
       repository: @repo,
-      url: @url
+      url: url
     }.to_json
+  end
+
+  def important?
+    labels.include? 'soon'
+  end
+
+  def url
+    @additional[:url]
+  end
+
+  def labels
+    @additional[:labels]
   end
 end

--- a/test/test_issue.rb
+++ b/test/test_issue.rb
@@ -37,4 +37,26 @@ class TestIssue < Minitest::Test
     JSON
     assert_equal expected, issue.to_json
   end
+
+  def test_important_issue
+    issue = Issue.new(
+      'Important Issue Title',
+      'Important Issue Body',
+      'jeo-maven-plugin',
+      531,
+      labels: ['soon']
+    )
+    assert issue.important?
+  end
+
+  def test_unimportant_issue
+    issue = Issue.new(
+      'Unimportant Issue Title',
+      'Unimportant Issue Body',
+      'jeo-maven-plugin',
+      531,
+      labels: ['not-soon']
+    )
+    assert !issue.important?
+  end
 end

--- a/test/test_pdd_issue.rb
+++ b/test/test_pdd_issue.rb
@@ -66,4 +66,14 @@ class TestPddIssue < Minitest::Test
       issue.to_json
     )
   end
+
+  def test_important_issue
+    issue = PddIssue.new('Title', 'Body', 'jeo-maven-plugin', 531, labels: ['soon'])
+    assert issue.important?
+  end
+
+  def test_unimportant_issue
+    issue = PddIssue.new('Title', 'Body', 'jeo-maven-plugin', 531)
+    assert !issue.important?
+  end
 end

--- a/test/test_report.rb
+++ b/test/test_report.rb
@@ -66,7 +66,7 @@ class TestReport < Minitest::Test
        - title: title, repo: repo, url: http://some.url.com
 
       Open Issues:
-       - title: title, repo: repo, number: #123, url: http://google.com
+       - title: title, repo: repo, number: #123, url: http://google.com, labels: []
     EXPECTED
     issues = [Issue.new('title', 'body', 'repo', '123', url: 'http://google.com')]
     prs = [PullRequest.new('repo', 'title', 'body', url: 'http://some.url.com')]


### PR DESCRIPTION
In this PR I added support of `soon` label for issues. Now, newsman will use only issues with `soon` label to build a report.

History:
- **feat: generalize issues params**
- **feat: fix all the code offenses**
- **feat: filter only important issues**
- **feat: fix all tests and code formatting**
