### PR TITLE
fix(#206): Support temperature handling for all reasoning models

### DIFF
--- a/lib/newsman/assistant.rb
+++ b/lib/newsman/assistant.rb
@@ -112,32 +112,32 @@ class Assistant
     send(prompt)
   end
 
-  # rubocop:disable Metrics/MethodLength
+  # OpenAI's reasoning-family models (o1, o3, o4-mini, gpt-5, ...) only accept
+  # the default temperature (1) and reject any explicit value with a 400.
+  # Their "-chat" flavors (e.g. gpt-5-chat-latest) are non-reasoning and
+  # support a custom temperature just like gpt-4o, gpt-3.5-turbo, etc.
+  FIXED_TEMPERATURE_MODELS = /\A(o[1-9]|gpt-5)/
+
   def send(request)
+    parameters = { model: @model, messages: messages(request) }
+    parameters[:temperature] = @temperature unless fixed_temperature?
+    @client.chat(parameters: parameters).dig('choices', 0, 'message', 'content')
+  end
+
+  def fixed_temperature?
+    @model.match?(FIXED_TEMPERATURE_MODELS) && !@model.include?('chat')
+  end
+
+  SYSTEM_PROMPT = 'You are a developer tasked with composing a concise report detailing'\
+    ' your activities and progress for the previous week, intended for submission to your supervisor.'
+
+  def messages(request)
     if @model == 'o1-preview'
-      @client.chat(
-        parameters: {
-          model: @model,
-          messages: [{ role: 'user', content: request.to_s }]
-        }
-      ).dig('choices', 0, 'message', 'content')
+      [{ role: 'user', content: request.to_s }]
     else
-      @client.chat(
-        parameters: {
-          model: @model,
-          messages: [
-            { role: 'system', content: 'You are a developer tasked'\
-  ' with composing a concise report detailing your activities'\
-  ' and progress for the previous week,'\
-  ' intended for submission to your supervisor.' },
-            { role: 'user', content: request.to_s }
-          ],
-          temperature: @temperature
-        }
-      ).dig('choices', 0, 'message', 'content')
+      [{ role: 'system', content: SYSTEM_PROMPT }, { role: 'user', content: request.to_s }]
     end
   end
-  # rubocop:enable Metrics/MethodLength
 
   def deprecated(method)
     warn "Warning! '#{method}' is deprecated and will be removed in future versions."

--- a/test/test_assistant.rb
+++ b/test/test_assistant.rb
@@ -35,4 +35,31 @@ class TestAssistant < Minitest::Test
     assert_equal expected,
                  assistant.say_hello
   end
+
+  def test_fixed_temperature_for_reasoning_models
+    %w[o1 o1-preview o1-mini o3 o3-mini o4-mini gpt-5 gpt-5-mini gpt-5.6].each do |model|
+      assistant = Assistant.new('test-token', model: model)
+      assert(assistant.fixed_temperature?, "expected #{model} to have a fixed temperature")
+    end
+  end
+
+  def test_custom_temperature_for_chat_models
+    %w[gpt-3.5-turbo gpt-4o gpt-4.1 gpt-5-chat-latest].each do |model|
+      assistant = Assistant.new('test-token', model: model)
+      refute(assistant.fixed_temperature?, "expected #{model} to allow a custom temperature")
+    end
+  end
+
+  def test_o1_preview_skips_system_message
+    assistant = Assistant.new('test-token', model: 'o1-preview')
+    messages = assistant.messages('do something')
+    assert_equal([{ role: 'user', content: 'do something' }], messages)
+  end
+
+  def test_other_models_keep_system_message
+    assistant = Assistant.new('test-token', model: 'gpt-5.6')
+    messages = assistant.messages('do something')
+    assert_equal(2, messages.size)
+    assert_equal('system', messages.first[:role])
+  end
 end


### PR DESCRIPTION
Fixes HTTP 400 errors when using reasoning-family models like `gpt-5.6` by generalizing the temperature parameter handling to detect all models with fixed temperature requirements, not just `o1-preview`.

Fixes #206