### PR TITLE
feat(#208): add markdown header and list support to docx output

### DIFF
--- a/lib/newsman/docx_output.rb
+++ b/lib/newsman/docx_output.rb
@@ -30,7 +30,7 @@ class Docxout
   # Content types part, required by every OOXML package.
   CONTENT_TYPES = <<~XML
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-    <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>
+    <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/><Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/></Types>
   XML
 
   # Package-level relationships, pointing at the main document part.
@@ -38,6 +38,25 @@ class Docxout
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>
   XML
+
+  # Document-level relationships, pointing at the numbering part used by lists.
+  DOCUMENT_RELS = <<~XML
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" Target="numbering.xml"/></Relationships>
+  XML
+
+  # Numbering definitions: numId 1 is a bulleted list, numId 2 is a decimal (numbered) list.
+  NUMBERING = <<~XML
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:abstractNum w:abstractNumId="0"><w:lvl w:ilvl="0"><w:numFmt w:val="bullet"/><w:lvlText w:val="&#8226;"/><w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl></w:abstractNum><w:abstractNum w:abstractNumId="1"><w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/><w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl></w:abstractNum><w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num><w:num w:numId="2"><w:abstractNumId w:val="1"/></w:num></w:numbering>
+  XML
+
+  # Matches markdown headers, e.g. "## Title" (levels 1-6).
+  HEADING = /^\s{0,3}(\#{1,6})\s+(.+?)\s*$/
+  # Matches markdown bullet list items, e.g. "- item" or "* item".
+  BULLET = /^\s{0,3}[-*]\s+(.+?)\s*$/
+  # Matches markdown numbered list items, e.g. "1. item".
+  NUMBERED = /^\s{0,3}\d+\.\s+(.+?)\s*$/
 
   FONT = 'Times New Roman'
   # Word expresses font size in half-points, so 12pt is 24.
@@ -50,11 +69,7 @@ class Docxout
   def print(report, reporter, model)
     puts "Create a docx file in a directory #{@root}"
     path = File.join(@root, filename(reporter, model))
-    Zip::File.open(path, create: true) do |zip|
-      zip.get_output_stream('[Content_Types].xml') { |f| f.write(CONTENT_TYPES) }
-      zip.get_output_stream('_rels/.rels') { |f| f.write(RELS) }
-      zip.get_output_stream('word/document.xml') { |f| f.write(document_xml(report)) }
-    end
+    write_package(path, report)
     puts "Report was successfully printed to a #{path}"
     File.basename(path)
   end
@@ -67,16 +82,63 @@ class Docxout
 
   private
 
+  def write_package(path, report)
+    Zip::File.open(path, create: true) do |zip|
+      zip.get_output_stream('[Content_Types].xml') { |f| f.write(CONTENT_TYPES) }
+      zip.get_output_stream('_rels/.rels') { |f| f.write(RELS) }
+      zip.get_output_stream('word/_rels/document.xml.rels') { |f| f.write(DOCUMENT_RELS) }
+      zip.get_output_stream('word/numbering.xml') { |f| f.write(NUMBERING) }
+      zip.get_output_stream('word/document.xml') { |f| f.write(document_xml(report)) }
+    end
+  end
+
   def document_xml(report)
-    body = paragraphs(report).map { |lines| paragraph_xml(lines) }.join
+    body = blocks(report).map { |block| block_xml(block) }.join
     <<~XML
       <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
       <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>#{body}<w:sectPr/></w:body></w:document>
     XML
   end
 
-  def paragraphs(report)
-    report.to_s.split(/\n{2,}/).map { |paragraph| paragraph.split("\n") }
+  # Splits the report into blocks: markdown headers and list items each become
+  # their own block, and consecutive plain-text lines are grouped together.
+  def blocks(report)
+    classified = report.to_s.split("\n", -1).map { |line| classify(line) }
+    classified.chunk_while { |prev, curr| prev[:type] == :text && curr[:type] == :text }
+              .reject { |group| group.first[:type] == :blank }
+              .map { |group| merge_text(group) }
+  end
+
+  def merge_text(group)
+    return group.first unless group.first[:type] == :text
+
+    { type: :text, lines: group.map { |block| block[:line] } }
+  end
+
+  def classify(line)
+    return { type: :blank } if line.strip.empty?
+    return { type: :heading, level: ::Regexp.last_match(1).length, text: ::Regexp.last_match(2) } if line =~ HEADING
+    return { type: :bullet, text: ::Regexp.last_match(1) } if line =~ BULLET
+    return { type: :numbered, text: ::Regexp.last_match(1) } if line =~ NUMBERED
+
+    { type: :text, line: line }
+  end
+
+  def block_xml(block)
+    case block[:type]
+    when :heading
+      "<w:p><w:pPr><w:pStyle w:val=\"Heading#{block[:level]}\"/></w:pPr>#{run_xml(block[:text])}</w:p>"
+    when :bullet
+      list_item_xml(block[:text], '1')
+    when :numbered
+      list_item_xml(block[:text], '2')
+    else
+      paragraph_xml(block[:lines])
+    end
+  end
+
+  def list_item_xml(text, num_id)
+    "<w:p><w:pPr><w:numPr><w:ilvl w:val=\"0\"/><w:numId w:val=\"#{num_id}\"/></w:numPr></w:pPr>#{run_xml(text)}</w:p>"
   end
 
   def paragraph_xml(lines)

--- a/test/test_docxout.rb
+++ b/test/test_docxout.rb
@@ -50,4 +50,50 @@ class TestDocxout < Minitest::Test
       assert_includes(document_xml, 'Issue description')
     end
   end
+
+  def test_renders_markdown_headers_as_word_headings
+    Dir.mktmpdir do |temp_dir|
+      output = Docxout.new(temp_dir)
+      report = "# Title\n\n## Subtitle\n\n### Section"
+      path = File.join(temp_dir, output.print(report, 'volodya-lombrozo', 'gpt-3.5-turbo'))
+      document_xml = Zip::File.open(path) { |zip| zip.read('word/document.xml') }
+      %w[Heading1 Heading2 Heading3].each { |style| assert_includes(document_xml, %(<w:pStyle w:val="#{style}"/>)) }
+      assert_includes(document_xml, '>Title<')
+      refute_includes(document_xml, '# Title')
+    end
+  end
+
+  def test_renders_markdown_bullet_lists_as_word_lists
+    Dir.mktmpdir do |temp_dir|
+      output = Docxout.new(temp_dir)
+      report = "List is here:\n\n- one\n- two\n* three"
+      path = File.join(temp_dir, output.print(report, 'volodya-lombrozo', 'gpt-3.5-turbo'))
+      document_xml = Zip::File.open(path) { |zip| zip.read('word/document.xml') }
+      assert_includes(document_xml, '<w:numId w:val="1"/>')
+      assert_includes(document_xml, '>one<')
+      refute_includes(document_xml, '>- one<')
+    end
+  end
+
+  def test_renders_markdown_numbered_lists_as_word_lists
+    Dir.mktmpdir do |temp_dir|
+      output = Docxout.new(temp_dir)
+      report = "1. first\n2. second"
+      path = File.join(temp_dir, output.print(report, 'volodya-lombrozo', 'gpt-3.5-turbo'))
+      document_xml = Zip::File.open(path) { |zip| zip.read('word/document.xml') }
+      assert_includes(document_xml, '<w:numId w:val="2"/>')
+      assert_includes(document_xml, '>first<')
+    end
+  end
+
+  def test_docx_package_includes_a_valid_numbering_part
+    Dir.mktmpdir do |temp_dir|
+      output = Docxout.new(temp_dir)
+      path = File.join(temp_dir, output.print("- one\n- two", 'volodya-lombrozo', 'gpt-3.5-turbo'))
+      Zip::File.open(path) do |zip|
+        assert(zip.find_entry('word/numbering.xml'))
+        assert(zip.find_entry('word/_rels/document.xml.rels'))
+      end
+    end
+  end
 end


### PR DESCRIPTION
Implement markdown syntax support in `Docxout` to render headers and lists as proper Word formatting instead of literal text.

This enables the generated `.docx` reports to be used as-is with real heading styles and list formatting, matching the quality of the HTML output.

Fixes #208