### PR TITLE
feat(#209): group dependency-bump PRs into single bullet

### DIFF
--- a/lib/newsman/assistant.rb
+++ b/lib/newsman/assistant.rb
@@ -45,7 +45,8 @@ class Assistant
     example = "repository-name:\n
       - To publish ABC package draft [#27]\n
       - To review first draft of the report [#56]\n
-      - To implement optimization for the class X [#125]"
+      - To implement optimization for the class X [#125]\n
+      - Updated dependencies: rubocop, ruby [#197, #199, #204]"
     prompt = <<~PROMPT
       Please compile a summary of the plans for the next week using the GitHub Issues.
       Each issue should be summarized in a single sentence.
@@ -53,6 +54,8 @@ class Assistant
       Pay attention, that you didn't loose any issue.
       Ensure that each sentence includes the corresponding issue number as an integer value. If an issue doesn't mention an issue number, just print [#chore].
       If several issues have the same number, combine them into a single sentence.
+      Dependency version-bump issues (e.g. titles like "chore(deps): update dependency X to vY" or similar renovate/dependabot style bumps) must all be grouped into a single combined bullet listing the dependency names and all associated issue numbers, instead of one bullet per issue.
+      Other substantive issues should keep their own individual bullet as usual.
       Please strictly adhere to the example template provided: "#{example}".
       List of GitHub Issues in JSON format: ```json #{issues}```.
     PROMPT
@@ -65,13 +68,16 @@ class Assistant
     example = "repository-name:\n
       - Added 100 new files to the Dataset [#168]\n
       - Fixed the deployment of XYZ [#169]\n
-      - Refined the requirements [#177]\n"
+      - Refined the requirements [#177]\n
+      - Updated dependencies: rubocop, ruby, nokogiri [#197, #199, #200, #202, #203, #204]\n"
     prompt = <<~PROMPT
       Please compile a summary of the work completed in the following Pull Requests (PRs).
       Each PR should be summarized in a single sentence, focusing on the PR title rather than the implementation details.
       Ensure no PR is omitted.
       Each sentence must include the corresponding issue number as an integer value. If a PR does not mention an issue number, use [#chore].
       If several PRs have the same number, combine them into a single sentence.
+      Dependency version-bump PRs (e.g. titles like "chore(deps): update dependency X to vY" or similar renovate/dependabot style bumps) must all be grouped into a single combined bullet listing the dependency names and all associated PR numbers, instead of one bullet per PR.
+      Other substantive PRs should keep their own individual bullet as usual.
       Combine the information from each PR into a concise and fluent sentence.
       Follow the provided example template strictly: "#{example}".
       List of Pull Requests in JSON format: ```json #{prs}```.


### PR DESCRIPTION
Groups dependency-bump PRs and issues into a single combined bullet point in `Assistant` prompts, reducing clutter in weekly reports by consolidating routine dependency updates while keeping substantive changes as individual bullets.

Fixes #209