### PR TITLE
fix(#215): strip markdown bold markers from DOCX output

### DIFF
--- a/lib/newsman/docx_output.rb
+++ b/lib/newsman/docx_output.rb
@@ -57,6 +57,8 @@ class Docxout
   BULLET = /^\s{0,3}[-*]\s+(.+?)\s*$/
   # Matches markdown numbered list items, e.g. "1. item".
   NUMBERED = /^\s{0,3}\d+\.\s+(.+?)\s*$/
+  # Matches markdown bold markers, e.g. "**bold**" or "__bold__".
+  BOLD = /(\*\*|__)(.+?)\1/
 
   FONT = 'Times New Roman'
   # Word expresses font size in half-points, so 12pt is 24.
@@ -151,6 +153,6 @@ class Docxout
   def run_xml(line)
     "<w:r><w:rPr><w:rFonts w:ascii=\"#{FONT}\" w:hAnsi=\"#{FONT}\" w:cs=\"#{FONT}\"/>" \
       "<w:sz w:val=\"#{SIZE}\"/><w:szCs w:val=\"#{SIZE}\"/></w:rPr>" \
-      "<w:t xml:space=\"preserve\">#{CGI.escapeHTML(line)}</w:t></w:r>"
+      "<w:t xml:space=\"preserve\">#{CGI.escapeHTML(line.gsub(BOLD, '\2'))}</w:t></w:r>"
   end
 end

--- a/test/test_docxout.rb
+++ b/test/test_docxout.rb
@@ -86,6 +86,18 @@ class TestDocxout < Minitest::Test
     end
   end
 
+  def test_strips_markdown_bold_markers
+    Dir.mktmpdir do |temp_dir|
+      output = Docxout.new(temp_dir)
+      report = 'Deploys are **blocked** until review, __really__ blocked.'
+      path = File.join(temp_dir, output.print(report, 'volodya-lombrozo', 'gpt-3.5-turbo'))
+      document_xml = Zip::File.open(path) { |zip| zip.read('word/document.xml') }
+      assert_includes(document_xml, 'Deploys are blocked until review, really blocked.')
+      refute_includes(document_xml, '**')
+      refute_includes(document_xml, '__')
+    end
+  end
+
   def test_docx_package_includes_a_valid_numbering_part
     Dir.mktmpdir do |temp_dir|
       output = Docxout.new(temp_dir)


### PR DESCRIPTION
This PR fixes an issue where `Docxout` was leaving markdown bold markers (`**` and `__`) in generated DOCX documents instead of stripping them. The solution adds a regex pattern to detect and remove these markers from text runs before they are written to the Word document output.

Fixes #215