### PR TITLE
feat(#216): add maintainer activity metrics to report

### DIFF
--- a/lib/newsman.rb
+++ b/lib/newsman.rb
@@ -99,6 +99,8 @@ def generate
   github = Github.new(github_token)
   prs = github.pull_requests(github_username, github_repositories)
   issues = github.issues(github_username, github_repositories)
+  issues_reviewed = github.issues_reviewed(github_username, github_repositories)
+  prs_reviewed = github.pull_requests_reviewed(github_username, github_repositories)
   puts "\nNow lets test some aggregation using OpenAI\n\n"
   assistant = Assistant.new(openai_token, model: options[:model])
   # Build previous results
@@ -118,7 +120,7 @@ def generate
     reporter,
     reporter_position,
     options[:title],
-    additional: ReportItems.new(prs, issues)
+    additional: ReportItems.new(prs, issues, issues_reviewed: issues_reviewed, prs_reviewed: prs_reviewed)
   )
   full_answer = assistant.format(report.build(
                                    answer,

--- a/lib/newsman/github.rb
+++ b/lib/newsman/github.rb
@@ -24,8 +24,8 @@
 
 # This class represents a useful abstraction over Github API.
 class Github
-  def initialize(token)
-    @client = Octokit::Client.new(github_token: token)
+  def initialize(token, client: nil)
+    @client = client || Octokit::Client.new(github_token: token)
   end
 
   def pull_requests(username, repositories)
@@ -46,6 +46,24 @@ class Github
     @client.search_issues(query).items.map do |issue|
       parse_issue(issue)
     end.select(&:important?)
+  end
+
+  def issues_reviewed(username, repositories)
+    since = date_one_week_ago(Date.today)
+    reviewed_query = "is:issue involves:#{username} updated:>=#{since} #{repositories}"
+    closed_query = "is:issue is:closed involves:#{username} closed:>=#{since} #{repositories}"
+    puts "Searching issues reviewed using the following query: '#{reviewed_query}'"
+    reviewed = @client.search_issues(reviewed_query).total_count
+    puts "Searching issues closed using the following query: '#{closed_query}'"
+    closed = @client.search_issues(closed_query).total_count
+    IssueActivity.new(reviewed, closed)
+  end
+
+  def pull_requests_reviewed(username, repositories)
+    since = date_one_week_ago(Date.today)
+    query = "is:pr reviewed-by:#{username} updated:>=#{since} #{repositories}"
+    puts "Searching pull requests reviewed using the following query: '#{query}'"
+    @client.search_issues(query).total_count
   end
 
   def parse_pr(pull_request)

--- a/lib/newsman/issues.rb
+++ b/lib/newsman/issues.rb
@@ -25,6 +25,21 @@ require 'json'
 
 IMPORTANT_ISSUE = 'soon'
 
+# Represents how many issues a user reviewed (labeled, assigned, commented, etc.)
+# and how many of those were closed, during a given period.
+class IssueActivity
+  attr_reader :reviewed, :closed
+
+  def initialize(reviewed, closed)
+    @reviewed = reviewed
+    @closed = closed
+  end
+
+  def to_s
+    "Issues reviewed: #{@reviewed} (labeled/assigned), #{@closed} closed"
+  end
+end
+
 # This class represents a GitHub Issue abstraction created by a user.
 class Issue
   attr_accessor :title, :body, :repo, :number

--- a/lib/newsman/report.rb
+++ b/lib/newsman/report.rb
@@ -65,9 +65,11 @@ end
 
 # Report items inner class.
 class ReportItems
-  def initialize(prs, issues)
+  def initialize(prs, issues, issues_reviewed: nil, prs_reviewed: nil)
     @prs = prs || []
     @issues = issues || []
+    @issues_reviewed = issues_reviewed
+    @prs_reviewed = prs_reviewed
   end
 
   # Returns true if there are no pull requests or issues, false otherwise
@@ -78,6 +80,15 @@ class ReportItems
   def to_s
     prs_list = @prs.map(&:detailed_title).map { |obj| " - #{obj}\n" }.join
     issues_list = @issues.map(&:detailed_title).map { |obj| " - #{obj}\n" }.join
-    "Closed Pull Requests:\n#{prs_list}\nOpen Issues:\n#{issues_list}"
+    "Closed Pull Requests:\n#{prs_list}\nOpen Issues:\n#{issues_list}#{activity}"
+  end
+
+  private
+
+  def activity
+    return '' unless @issues_reviewed || @prs_reviewed
+
+    lines = [@issues_reviewed&.to_s, (@prs_reviewed ? "PRs reviewed: #{@prs_reviewed}" : nil)].compact
+    "\n#{lines.join("\n")}\n"
   end
 end

--- a/test/test_github.rb
+++ b/test/test_github.rb
@@ -1,0 +1,77 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Copyright (c) 2024 Volodya Lombrozo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the 'Software'), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+require 'minitest/autorun'
+require_relative '../lib/newsman/issues'
+require_relative '../lib/newsman/github'
+
+# A fake Octokit client that records every query it receives and answers
+# with a canned total_count, so we can assert on the query strings we build
+# without touching the network.
+class FakeOctokit
+  Result = Struct.new(:total_count, :items)
+
+  def initialize(counts)
+    @counts = counts
+    @queries = []
+  end
+
+  attr_reader :queries
+
+  def search_issues(query)
+    @queries << query
+    Result.new(@counts.fetch(query, 0), [])
+  end
+end
+
+class TestGithub < Minitest::Test
+  def test_issues_reviewed_builds_involves_and_closed_queries
+    client = FakeOctokit.new({})
+    github = Github.new('token', client: client)
+    github.issues_reviewed('volodya-lombrozo', 'repo:objectionary/eo')
+    assert(client.queries.any? { |q| q.include?('is:issue') && q.include?('involves:volodya-lombrozo') })
+    assert(client.queries.any? do |q|
+      q.include?('is:issue') && q.include?('is:closed') && q.include?('involves:volodya-lombrozo')
+    end)
+  end
+
+  def test_issues_reviewed_returns_reviewed_and_closed_counts
+    since = date_one_week_ago(Date.today)
+    reviewed_query = "is:issue involves:volodya-lombrozo updated:>=#{since} repo:objectionary/eo"
+    closed_query = "is:issue is:closed involves:volodya-lombrozo closed:>=#{since} repo:objectionary/eo"
+    client = FakeOctokit.new(reviewed_query => 7, closed_query => 3)
+    github = Github.new('token', client: client)
+    activity = github.issues_reviewed('volodya-lombrozo', 'repo:objectionary/eo')
+    assert_equal 7, activity.reviewed
+    assert_equal 3, activity.closed
+    assert_equal 'Issues reviewed: 7 (labeled/assigned), 3 closed', activity.to_s
+  end
+
+  def test_pull_requests_reviewed_builds_reviewed_by_query
+    since = date_one_week_ago(Date.today)
+    query = "is:pr reviewed-by:volodya-lombrozo updated:>=#{since} repo:objectionary/eo"
+    client = FakeOctokit.new(query => 5)
+    github = Github.new('token', client: client)
+    assert_equal 5, github.pull_requests_reviewed('volodya-lombrozo', 'repo:objectionary/eo')
+  end
+end

--- a/test/test_report.rb
+++ b/test/test_report.rb
@@ -73,4 +73,17 @@ class TestReport < Minitest::Test
     actual = ReportItems.new(prs, issues).to_s
     assert_equal expected, actual
   end
+
+  def test_report_items_with_activity_metrics
+    expected = <<~EXPECTED
+      Closed Pull Requests:
+
+      Open Issues:
+
+      Issues reviewed: 7 (labeled/assigned), 3 closed
+      PRs reviewed: 5
+    EXPECTED
+    actual = ReportItems.new([], [], issues_reviewed: IssueActivity.new(7, 3), prs_reviewed: 5).to_s
+    assert_equal expected, actual
+  end
 end


### PR DESCRIPTION
Add maintainer activity metrics to track issues touched and PRs reviewed during a reporting period. This enhancement provides visibility into triage and review work by including counters for issues labeled/assigned/closed and pull requests reviewed in the generated report.

Fixes #216