### PR TITLE
fix(#220): include reviewed activity in empty check

### DIFF
--- a/lib/newsman/report.rb
+++ b/lib/newsman/report.rb
@@ -72,9 +72,9 @@ class ReportItems
     @prs_reviewed = prs_reviewed
   end
 
-  # Returns true if there are no pull requests or issues, false otherwise
+  # Returns true if there are no pull requests, issues, or reviewed activity, false otherwise
   def empty?
-    @prs.empty? && @issues.empty?
+    @prs.empty? && @issues.empty? && @issues_reviewed.nil? && @prs_reviewed.nil?
   end
 
   def to_s

--- a/test/test_report.rb
+++ b/test/test_report.rb
@@ -86,4 +86,11 @@ class TestReport < Minitest::Test
     actual = ReportItems.new([], [], issues_reviewed: IssueActivity.new(7, 3), prs_reviewed: 5).to_s
     assert_equal expected, actual
   end
+
+  def test_append_additional_keeps_reviewed_activity_when_no_prs_or_issues
+    additional = ReportItems.new([], [], issues_reviewed: IssueActivity.new(0, 0), prs_reviewed: 9)
+    report = Report.new('User', 'Developer', 'Project', additional: additional)
+    actual = report.append_additional('BASE REPORT')
+    assert_includes actual, 'PRs reviewed: 9'
+  end
 end


### PR DESCRIPTION
Fix `empty?` method to properly account for reviewed activity in weekly reports

This PR corrects the `empty?` method in `ReportItems` to include reviewed pull requests and issues when determining if a report is empty. This ensures that review data is properly displayed in weekly reports instead of being incorrectly filtered out.

Fixes #220